### PR TITLE
Add dev script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "start": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
+    "dev": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
     "build": "rimraf dist && tsc && node --max-old-space-size=4096 node_modules/rollup/dist/bin/rollup -c rollup.config.mjs",
     "start:build": "web-dev-server --root-dir dist --app-index index.html --open",
     "lint": "eslint \"**/*.{js,ts}\" --ignore-path .gitignore",


### PR DESCRIPTION
This PR adds a new `dev` script to package.json that mirrors the functionality of the existing `start` script. This provides developers with an alternative command to start the development server.

The new script runs TypeScript compilation followed by concurrent execution of TypeScript in watch mode and the web dev server.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=orbit-studio&projectId=2e1b72ed6c2b4cb4a21a8e5c8b735741)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2e1b72ed6c2b4cb4a21a8e5c8b735741</projectId>-->